### PR TITLE
Fix color theme to match devtools setting

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -49,6 +49,11 @@ window.customElements.define('accordion-view', AccordionViewElement);
 window.customElements.define('devtools-message', DevtoolsMessageElement);
 window.customElements.define('devtools-button', DevtoolsButtonElement);
 
+// match browser devtools theme setting
+if (browser.devtools.panels.themeName === 'dark') {
+  document.documentElement.classList.add('-theme-with-dark-background');
+}
+
 const agent = getAgent(window.navigator.userAgent);
 console.log('Parsed agent:', agent);
 if (agent.os.name === 'window') {

--- a/src/app/styles/app.css
+++ b/src/app/styles/app.css
@@ -12,7 +12,7 @@
   --tree-item-hover-selected-background-color: var(--selection-bg-color);
   --tree-item-indent-per-level: 10px;
   --tree-item-row-height: 20px;
-  --tree-item-border-color: #ccc;
+  --tree-item-border-color: var(--divider-color);
   --key-value-height: 30px;
   --key-value-divider-position: 40%;
 }

--- a/src/app/styles/devtools.css
+++ b/src/app/styles/devtools.css
@@ -34,7 +34,7 @@
     --selection-inactive-fg-color: #cdcdcd;
     --selection-inactive-bg-color: hsl(0, 0%, 28%);
     --tab-selected-fg-color: #eaeaea;
-    --tab-selected-bg-color: black;
+    --tab-selected-bg-color: var(--toolbar-bg-color);
     --drop-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2),
                    0 2px 4px 2px rgba(0, 0, 0, 0.2),
                    0 2px 6px 2px rgba(0, 0, 0, 0.1);
@@ -64,6 +64,11 @@ body {
   -webkit-user-select: none;
   color: #222;
   background: white;
+}
+
+html.-theme-with-dark-background > body {
+	color: #d5d5d5;
+	background: #242424;
 }
 
 .platform-linux {


### PR DESCRIPTION
This switches the color theme to match the devtools theme setting.

Works in both chrome and firefox.