### PR TITLE
Fix layout overflow

### DIFF
--- a/src/app/common-elements/TreeItemElement.js
+++ b/src/app/common-elements/TreeItemElement.js
@@ -255,7 +255,7 @@ export default class TreeItemElement extends LitElement {
   :host([depth]) {
     border-top: 1px solid var(--tree-item-border-color);
   }
-  :host([depth="0"]) {
+  :host([depth="0"]), :host([depth="-1"]) {
     border: 0;
   }
   :host([depth="0"]) #children {

--- a/src/app/elements/GeometryViewElement.js
+++ b/src/app/elements/GeometryViewElement.js
@@ -18,14 +18,14 @@ export default class GeometryViewElement extends BaseElement {
     return html`
 <style>
   :host {
-    display: block;
+    display: flex;
+    flex-direction: column;
     width: 100%;
     height: 100%;
   }
 
   .properties {
-    height: auto;
-    max-height: 100%;
+    flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
   }

--- a/src/app/elements/MaterialViewElement.js
+++ b/src/app/elements/MaterialViewElement.js
@@ -47,14 +47,14 @@ export default class MaterialViewElement extends BaseElement {
     return html`
 <style>
   :host {
-    display: block;
+    display: flex;
+    flex-direction: column;
     width: 100%;
     height: 100%;
   }
 
   .properties {
-    height: auto;
-    max-height: 100%;
+    flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
   }

--- a/src/app/elements/ObjectViewElement.js
+++ b/src/app/elements/ObjectViewElement.js
@@ -23,14 +23,14 @@ export default class ObjectViewElement extends BaseElement {
     return html`
 <style>
   :host {
-    display: block;
+    display: flex;
+    flex-direction: column;
     width: 100%;
     height: 100%;
   }
 
   .properties {
-    height: auto;
-    max-height: 100%;
+    flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
   }

--- a/src/app/elements/RendererViewElement.js
+++ b/src/app/elements/RendererViewElement.js
@@ -55,14 +55,14 @@ export default class RendererViewElement extends BaseElement {
     return html`
 <style>
   :host {
-    display: block;
+    display: flex;
+    flex-direction: column;
     width: 100%;
     height: 100%;
   }
 
   .properties {
-    height: auto;
-    max-height: 100%;
+    flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
   }

--- a/src/app/elements/ResourcesViewElement.js
+++ b/src/app/elements/ResourcesViewElement.js
@@ -68,16 +68,17 @@ export default class ResourcesViewElement extends LitElement {
     return html`
 <style>
   :host {
-    display: block;
+    display: flex;
+    flex-direction: column;
     width: 100%;
     height: 100%;
-    overflow-y: auto;
     overflow-x: hidden;
   }
 
   :host > tree-item {
-    height: auto;
-    max-height: 100%;
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
   }
 </style>
 <title-bar title="Resources"></title-bar>

--- a/src/app/elements/SceneViewElement.js
+++ b/src/app/elements/SceneViewElement.js
@@ -71,16 +71,17 @@ export default class SceneViewElement extends BaseElement {
     return html`
 <style>
   :host {
-    display: block;
+    display: flex;
+    flex-direction: column;
     width: 100%;
     height: 100%;
-    overflow-y: auto;
     overflow-x: hidden;
   }
 
   :host > tree-item {
-    height: auto;
-    max-height: 100%;
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
   }
 
   ${ChromeSelectStyle}

--- a/src/app/elements/TextureViewElement.js
+++ b/src/app/elements/TextureViewElement.js
@@ -23,14 +23,14 @@ export default class TextureViewElement extends BaseElement {
     return html`
 <style>
   :host {
-    display: block;
+    display: flex;
+    flex-direction: column;
     width: 100%;
     height: 100%;
   }
 
   .properties {
-    height: auto;
-    max-height: 100%;
+    flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
   }

--- a/src/app/elements/shared-styles/chrome-select.js
+++ b/src/app/elements/shared-styles/chrome-select.js
@@ -24,7 +24,7 @@ select {
     background-position: right center;
     background-repeat: no-repeat;
     min-height: 24px;
-    min-width: 80px;
+    min-width: 16px;
     background-size: 15px;
   }
 


### PR DESCRIPTION
I converted all the views from boxes to flex-boxes to fix some overflow and sizing issues. e.g. can't scroll to the bottom of material properties.

I also fixed the double border at the top of the tree in resources view.