### PR TITLE
Implement refresh functionality for the refresh buttons

### DIFF
--- a/src/app/elements/BaseElement.js
+++ b/src/app/elements/BaseElement.js
@@ -59,9 +59,15 @@ export default class BaseElement extends LitElement {
    */
   shouldUpdate(changedProperties) {
     if (this.app && changedProperties.has('uuid')) {
-      this.app.refresh(this.uuid, this.constructor.typeHint);
+      this.refresh();
     }
     return true;
+  }
+
+  refresh() {
+    if (this.app) {
+      this.app.refresh(this.uuid, this.constructor.typeHint);
+    }
   }
 
   [$onContentUpdate](e) {

--- a/src/app/elements/MaterialViewElement.js
+++ b/src/app/elements/MaterialViewElement.js
@@ -84,7 +84,7 @@ export default class MaterialViewElement extends BaseElement {
   }
 </style>
 <title-bar title="Material View">
-  <devtools-icon-button icon="refresh">
+  <devtools-icon-button icon="refresh" @click="${this.refresh}">
 </title-bar>
 <div class="properties" material-hint="${materialHint}">
   <key-value uuid="${this.uuid}" key-name="Type" .value="${material.type}" type="string" property="type"></key-value>

--- a/src/app/elements/ObjectViewElement.js
+++ b/src/app/elements/ObjectViewElement.js
@@ -39,7 +39,7 @@ export default class ObjectViewElement extends BaseElement {
   [object-hint="mesh"] .mesh { display: flex; }
 </style>
 <title-bar title="Object View">
-  <devtools-icon-button icon="refresh">
+  <devtools-icon-button icon="refresh" @click="${this.refresh}">
 </title-bar>
 <div class="properties" object-hint="${objectType}">
   <key-value uuid=${this.uuid} key-name="Type" .value="${object.type}" type="string" property="type"></key-value>

--- a/src/app/elements/ResourcesViewElement.js
+++ b/src/app/elements/ResourcesViewElement.js
@@ -82,7 +82,6 @@ export default class ResourcesViewElement extends LitElement {
   }
 </style>
 <title-bar title="Resources">
-  <devtools-icon-button icon="refresh">
 </title-bar>
 <tree-item
   tabindex="0"

--- a/src/app/elements/SceneViewElement.js
+++ b/src/app/elements/SceneViewElement.js
@@ -90,7 +90,7 @@ export default class SceneViewElement extends BaseElement {
   <select @change="${this[$onSceneSelect]}" class="chrome-select">
     ${scenes.map(scene => html`<option value="${scene.uuid}">${scene.uuid}</option>`)}
   </select>
-  <devtools-icon-button icon="refresh">
+  <devtools-icon-button icon="refresh" @click="${this.refresh}">
 </title-bar>
 ${createNode(scene)}
 `;

--- a/src/app/elements/TextureViewElement.js
+++ b/src/app/elements/TextureViewElement.js
@@ -57,7 +57,7 @@ export default class TextureViewElement extends BaseElement {
   }
 </style>
 <title-bar title="Texture View">
-  <devtools-icon-button icon="refresh">
+  <devtools-icon-button icon="refresh" @click="${this.refresh}">
 </title-bar>
 <div class="properties" texture-hint="${textureHint}">
   <image-preview uuid="${texture.image}"></image-preview>


### PR DESCRIPTION
Now appropriately refreshes the view with the latest content. The refresh button from Resources was removed, as it'll update whenever anything updates (e.g. updating the scene will update the resources view). Maybe in the future the resources view should be per-scene rather than all of them as well.

cc @jacobcoughenour 